### PR TITLE
Update GPG key URL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Add packagecloud apt key
   apt_key:
-    url: "https://packagecloud.io/gpg.key"
+    url: "https://packages.blackfire.io/gpg.key"
     state: present
 
 - name: Add packagecloud repository


### PR DESCRIPTION
Updated GPG key URL following documentation: https://blackfire.io/docs/up-and-running/installation